### PR TITLE
Added build dependencies for NixOS and bypassed a curl TLS issue.

### DIFF
--- a/alvr/xtask/src/command.rs
+++ b/alvr/xtask/src/command.rs
@@ -18,7 +18,7 @@ pub fn targz(sh: &Shell, source: &Path) -> Result<(), xshell::Error> {
 }
 
 pub fn download(sh: &Shell, url: &str, destination: &Path) -> Result<(), xshell::Error> {
-    cmd!(sh, "curl -L -o {destination} --url {url}").run()
+    cmd!(sh, "curl -L -k -o {destination} --url {url}").run()
 }
 
 pub fn make_symlink(sh: &Shell, file: &Path, symlink_file: &Path) -> Result<(), xshell::Error> {

--- a/packaging/nix/shell.nix
+++ b/packaging/nix/shell.nix
@@ -38,6 +38,12 @@ in mkShell {
     libxkbcommon
     jack2
     bear
+    unzip
+    nasm
+    cargo
+    libdrm
+    x264
+    x265
   ];
 
   VK_LAYER_PATH = "${lunarg}/etc/vulkan/explicit_layer.d:${vulkan-validation-layers}";


### PR DESCRIPTION
However, when starting the `alvr_launcher` that's present in the `target/release/`, the headset doesn't get detected.

Is that a known issue or a packaging one?